### PR TITLE
Change image button for snippits

### DIFF
--- a/b2sbackglassdesigner/b2sbackglassdesigner/classes/Images/ImageCollection.vb
+++ b/b2sbackglassdesigner/b2sbackglassdesigner/classes/Images/ImageCollection.vb
@@ -11,8 +11,32 @@
             Me.Add(New Images.ImageInfo(Images.eImageInfoType.Title4IlluminationSnippits, My.Resources.IMAGES_IlluminationSnippits))
         End Sub
 
-        Public Shadows Sub Insert(ByVal titletype As Images.eImageInfoType, ByVal item As Images.ImageInfo)
+        Public Shadows Sub Insert(ByVal titletype As eImageInfoType, ByVal item As ImageInfo)
+            If titletype = eImageInfoType.Title4IlluminationSnippits Then
+                Dim existing As Boolean = False
+                For Each imageInfo As ImageInfo In Me
+                    If imageInfo.Type = item.Type AndAlso imageInfo.Text = item.Text Then
+                        imageInfo.RefCount += 1
+                        Return
+                    End If
+                Next
+            End If
+
+            item.RefCount = 1
             MyBase.Insert(indexInImageList(titletype), item)
+        End Sub
+
+        Public Sub RemoveByTypeAndName(ByVal titletype As eImageInfoType, ByVal name As String)
+            For Each imageInfo As ImageInfo In Me
+                If imageInfo.Type = titletype AndAlso imageInfo.Text = name Then
+                    imageInfo.RefCount -= 1
+
+                    If imageInfo.RefCount = 0 Then
+                        MyBase.Remove(imageInfo)
+                        Return
+                    End If
+                End If
+            Next
         End Sub
 
         Public Sub Resize(ByVal _type As eImageInfoType, ByVal newimagesize As Size)

--- a/b2sbackglassdesigner/b2sbackglassdesigner/classes/Images/ImageInfo.vb
+++ b/b2sbackglassdesigner/b2sbackglassdesigner/classes/Images/ImageInfo.vb
@@ -25,6 +25,7 @@
         Public Type As eImageInfoType = eImageInfoType.Undefined
         Public Text As String = String.Empty
         Public Image As Image = Nothing
+        Public RefCount As Integer = 0
 
         Public BackgroundImageType As eBackgroundImageType = eBackgroundImageType.NotUsed
 

--- a/b2sbackglassdesigner/b2sbackglassdesigner/classes/PictureBox/Mouse.vb
+++ b/b2sbackglassdesigner/b2sbackglassdesigner/classes/PictureBox/Mouse.vb
@@ -165,6 +165,11 @@ Public Class Mouse
                 Select Case keycode
                     Case Keys.Delete
                         If TypeOf SelectedItem Is Illumination.BulbInfo Then
+                            Dim bulb As Illumination.BulbInfo = SelectedItem
+                            If bulb.IsImageSnippit Then
+                                Backglass.currentImages.RemoveByTypeAndName(Images.eImageInfoType.IlluminationSnippits, bulb.Name)
+                                B2SBackglassDesigner.formDesigner.RefreshImageInfoList()
+                            End If
                             Undo.AddEntry(New Undo.UndoEntry(Undo.Type.BulbRemoved, SelectedItem))
                             bulbs.Remove(SelectedItem)
                             SelectedBulb = Nothing
@@ -441,6 +446,11 @@ Public Class Mouse
         parent.Cursor = CalcMouseLocation(e.X, e.Y, , , , False)
         If IsMatchingX AndAlso (SelectedItem IsNot Nothing OrElse CopyDMDImageFromBackglass) Then
             If TypeOf SelectedItem Is Illumination.BulbInfo Then
+                Dim bulb As Illumination.BulbInfo = SelectedItem
+                If bulb.IsImageSnippit Then
+                    Backglass.currentImages.RemoveByTypeAndName(Images.eImageInfoType.IlluminationSnippits, bulb.Name)
+                    B2SBackglassDesigner.formDesigner.RefreshImageInfoList()
+                End If
                 Undo.AddEntry(New Undo.UndoEntry(Undo.Type.BulbRemoved, SelectedItem))
                 bulbs.Remove(SelectedItem)
                 SelectedBulb = Nothing

--- a/b2sbackglassdesigner/b2sbackglassdesigner/formDesigner.vb
+++ b/b2sbackglassdesigner/b2sbackglassdesigner/formDesigner.vb
@@ -1640,6 +1640,16 @@ Public Class formDesigner
         NoToolEvents = False
     End Sub
 
+    Public Sub RefreshImageInfoList()
+        If formToolResources IsNot Nothing Then
+            If Backglass.currentData IsNot Nothing Then
+                formToolResources.ImageInfoList = Backglass.currentData.Images
+                Backglass.currentTabPage.Invalidate()
+                Backglass.currentData.IsDirty = True
+            End If
+        End If
+    End Sub
+
     Private Sub CopyDMDArea()
         If Backglass.currentData IsNot Nothing Then
             With Backglass.currentData

--- a/b2sbackglassdesigner/b2sbackglassdesigner/forms/formSnippitSettings.Designer.vb
+++ b/b2sbackglassdesigner/b2sbackglassdesigner/forms/formSnippitSettings.Designer.vb
@@ -44,6 +44,7 @@ Partial Class formSnippitSettings
         Me.Label2 = New System.Windows.Forms.Label()
         Me.numericRotatingInterval = New System.Windows.Forms.NumericUpDown()
         Me.lblRotatingInterval = New System.Windows.Forms.Label()
+        Me.btnChangeImage = New System.Windows.Forms.Button()
         Me.groupGeneral.SuspendLayout()
         CType(Me.numericZOrder, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.grpRotating.SuspendLayout()
@@ -68,6 +69,7 @@ Partial Class formSnippitSettings
         'groupGeneral
         '
         resources.ApplyResources(Me.groupGeneral, "groupGeneral")
+        Me.groupGeneral.Controls.Add(Me.btnChangeImage)
         Me.groupGeneral.Controls.Add(Me.numericZOrder)
         Me.groupGeneral.Controls.Add(Me.lblZOrder)
         Me.groupGeneral.Controls.Add(Me.cmbType)
@@ -198,6 +200,12 @@ Partial Class formSnippitSettings
         resources.ApplyResources(Me.lblRotatingInterval, "lblRotatingInterval")
         Me.lblRotatingInterval.Name = "lblRotatingInterval"
         '
+        'btnChangeImage
+        '
+        resources.ApplyResources(Me.btnChangeImage, "btnChangeImage")
+        Me.btnChangeImage.Name = "btnChangeImage"
+        Me.btnChangeImage.UseVisualStyleBackColor = True
+        '
         'formSnippitSettings
         '
         Me.AcceptButton = Me.btnOk
@@ -244,4 +252,5 @@ Partial Class formSnippitSettings
     Friend WithEvents lblMechID As System.Windows.Forms.Label
     Friend WithEvents cmbRotationStopBehaviour As System.Windows.Forms.ComboBox
     Friend WithEvents lblRotationStopping As System.Windows.Forms.Label
+    Friend WithEvents btnChangeImage As Button
 End Class

--- a/b2sbackglassdesigner/b2sbackglassdesigner/forms/formSnippitSettings.resx
+++ b/b2sbackglassdesigner/b2sbackglassdesigner/forms/formSnippitSettings.resx
@@ -351,6 +351,33 @@
   <data name="&gt;&gt;txtName.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="btnChangeImage.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnChangeImage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>311, 73</value>
+  </data>
+  <data name="btnChangeImage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 23</value>
+  </data>
+  <data name="btnChangeImage.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="btnChangeImage.Text" xml:space="preserve">
+    <value>&amp;Change Image</value>
+  </data>
+  <data name="&gt;&gt;btnChangeImage.Name" xml:space="preserve">
+    <value>btnChangeImage</value>
+  </data>
+  <data name="&gt;&gt;btnChangeImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnChangeImage.Parent" xml:space="preserve">
+    <value>groupGeneral</value>
+  </data>
+  <data name="&gt;&gt;btnChangeImage.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
   <data name="groupGeneral.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 4</value>
   </data>

--- a/b2sbackglassdesigner/b2sbackglassdesigner/forms/formSnippitSettings.vb
+++ b/b2sbackglassdesigner/b2sbackglassdesigner/forms/formSnippitSettings.vb
@@ -115,4 +115,29 @@ Public Class formSnippitSettings
         cmbRotationStopBehaviour.Enabled = (cmbType.SelectedIndex = 1)
     End Sub
 
+    Private Sub btnChangeImage_Click(sender As Object, e As EventArgs) Handles btnChangeImage.Click
+        Dim bulb = Backglass.currentTabPage.Mouse.SelectedBulb
+        If bulb IsNot Nothing Then
+            Using fileDialog As OpenFileDialog = New OpenFileDialog
+                With fileDialog
+                    .Filter = ImageFileExtensionFilter
+                    .FileName = String.Empty
+                    .InitialDirectory = BackglassProjectsPath
+                    If .ShowDialog(Me) = DialogResult.OK Then
+                        Backglass.currentImages.RemoveByTypeAndName(Images.eImageInfoType.IlluminationSnippits, bulb.Name)
+
+                        bulb.Image = Bitmap.FromFile(.FileName).Copy(True)
+                        bulb.Name = IO.Path.GetFileNameWithoutExtension(.FileName)
+
+                        Dim imageInfo As Images.ImageInfo = New Images.ImageInfo(Images.eImageInfoType.IlluminationSnippits)
+                        imageInfo.Text = bulb.Name
+                        imageInfo.Image = bulb.Image
+                        Backglass.currentImages.Insert(Images.eImageInfoType.Title4IlluminationSnippits, imageInfo)
+
+                        B2SBackglassDesigner.formDesigner.RefreshImageInfoList()
+                    End If
+                End With
+            End Using
+        End If
+    End Sub
 End Class


### PR DESCRIPTION
This adds a "Change image" button to Snippit settings, to be used to replace the image on an existing Snippit.
This also contains a cleanup of the Resource window to only display a snippit image once, and adds a reference counter to the image so it gets removed when there no longer are any bulbs using the image.